### PR TITLE
Add scipy to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 cython
 click
 pytest
+scipy


### PR DESCRIPTION
`scipy.linalg` is used in `previewcontrol.py`, therefore it is needed for plain `make` to run through.